### PR TITLE
h2op: add sending, add crc, generalize stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_sock_udp
 # saul
 USEMODULE += saul_default
+# utilities
+USEMODULE += checksum
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ ROLE ?= sensor
 #TODO error for invalid values
 CFLAGS += -DNODE_ROLE=\"$(ROLE)\"
 
+# RFC 4193. (prefix fd, random bytes 9c..af, subnet id ac01)
+IPV6_NETWORK ?= 0xfd9c5921b4afac01
+#XXX is this okay? is this safe? is this the best way to do this?
+CFLAGS += -DH2O_NETWORK_PREFIX="((uint64_t)$(IPV6_NETWORK))"
+
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 

--- a/lib/network.c
+++ b/lib/network.c
@@ -3,8 +3,6 @@
 #include <string.h>
 
 #include "checksum/crc16_ccitt.h"
-// XXX I'm pretty sure that's not the way to do this but how do I do this
-#include "../RIOT/sys/checksum/crc16_ccitt.c"
 #include "net/sock/udp.h"
 #include "net/ipv6/addr.h"
 

--- a/lib/network.c
+++ b/lib/network.c
@@ -141,7 +141,6 @@ ssize_t h2op_send ( const nodeid_t recipient, H2OP_MSGTYPE type,
 
     ipv6_addr_t recipient_ip;
     h2op_nodeid_to_addr(recipient, &recipient_ip);
-    printf("to: "); ipv6_addr_print(&recipient_ip); puts("");
 
     //XXX: can this be written better (as a struct directly or something)?
     H2OP_HEADER *header = (H2OP_HEADER*) buf;
@@ -174,7 +173,7 @@ void h2op_debug_receive_handler ( uint8_t *buf, uint16_t packetlen ) {
         return;
     }
     if ( header->version != H2OP_VERSION ) {
-        error(0,0, "invalid version (got 0x%02X, want 0x01)", header->version);
+        error(0,0, "unknown version (got 0x%02X, want 0x01)", header->version);
         return;
     }
 

--- a/lib/network.c
+++ b/lib/network.c
@@ -1,8 +1,13 @@
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
+#include "checksum/crc16_ccitt.h"
+// XXX I'm pretty sure that's not the way to do this but how do I do this
+#include "../RIOT/sys/checksum/crc16_ccitt.c"
 #include "net/sock/udp.h"
 #include "net/ipv6/addr.h"
+
 #include "util.h"
 
 #define SERVER_MSG_QUEUE_SIZE (8)
@@ -13,9 +18,16 @@ static char server_buffer[SERVER_BUFFER_SIZE];
 static msg_t server_msg_queue[SERVER_MSG_QUEUE_SIZE];
 
 typedef void (*receive_handler) (char* buf, uint16_t buflen);
+typedef uint16_t nodeid_t;
 
-#define H2OP_SERVER_PORT (44555)
-static size_t H2OP_HEADER_LENGTH = 8;
+#define H2OP_PORT (44555)
+#define H2OP_MAGIC (0xAC)
+#define H2OP_VERSION (1)
+typedef enum {
+    H2OP_DATA_TEMPERATURE = 0x11,
+    H2OP_DATA_HUMIDITY = 0x12,
+    H2OP_WARN_BUCKET_EMPTY = 0x99,
+} H2OP_MSGTYPE;
 #pragma pack(push, 1)
 typedef struct {
     uint8_t magic;
@@ -26,6 +38,23 @@ typedef struct {
     uint16_t crc;
 } H2OP_HEADER;
 #pragma pack(pop)
+static size_t H2OP_HEADER_LENGTH = sizeof(H2OP_HEADER);
+
+void h2op_nodeid_to_addr ( nodeid_t nodeid, ipv6_addr_t *addr) {
+    switch(nodeid) {
+        case 0: // reserved
+            ipv6_addr_set_unspecified(addr);
+            error(0, 0, "Invalid value for nodeid: 0000");
+            break;
+        case 0xffff: // special address meaning broadcast (ff02::1)
+            ipv6_addr_set_all_nodes_multicast(addr, 2);
+            break;
+        default:
+            addr->u64[0] = byteorder_htonll((uint64_t) H2O_NETWORK_PREFIX);
+            addr->u64[1] = byteorder_htonll((uint64_t) nodeid);
+            break;
+    }
+}
 
 int rv; // generic declaration for return value (use locally only)
 
@@ -65,12 +94,75 @@ void udp_server(uint16_t port, receive_handler handler) {
     }
 }
 
+ssize_t udp_send ( const ipv6_addr_t *recipient, uint16_t port,
+                   const uint8_t *data, size_t data_len ) {
+    /* send an udp datagram. */
+    sock_udp_ep_t remote = {
+        .family = AF_INET6,
+        .port = port,
+    };
+    memcpy(&remote.addr, recipient, sizeof(*recipient));
+
+    if (ipv6_addr_is_link_local((ipv6_addr_t *)&remote.addr)) {
+        /* choose first interface when address is link local */
+        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+        remote.netif = (uint16_t)netif->pid;
+    }
+
+    ssize_t res = sock_udp_send(NULL, data, data_len, &remote);
+    // TODO error handling
+    return res;
+}
+
+void h2op_header_hton ( H2OP_HEADER *header ) {
+    header->node = htons(header->node);
+    header->crc = htons(header->crc);
+}
+
 void h2op_header_ntoh ( H2OP_HEADER *header ) {
     header->node = ntohs(header->node);
     header->crc = ntohs(header->crc);
 }
 
+ssize_t h2op_send ( const nodeid_t recipient, H2OP_MSGTYPE type,
+                    const char *data, size_t len, uint16_t source ) {
+    /* Send a H2OP message.
+     * @param recipient: recipient, node id. 0xffff is broadcast.
+     * @param type: message type, as per protocol definition
+     * @param data: message data
+     * @param len: length of data
+     * @param source: node id of data source
+     */
+    size_t buflen = H2OP_HEADER_LENGTH + len;
+    uint8_t *buf = malloc(buflen);
+    if ( buf == NULL ) {
+        error(0, errno, "Error while sending: Could not allocate memory");
+        return -ENOMEM;
+    }
+
+    ipv6_addr_t recipient_ip;
+    h2op_nodeid_to_addr(recipient, &recipient_ip);
+    printf("to: "); ipv6_addr_print(&recipient_ip); puts("");
+
+    //XXX: can this be written better (as a struct directly or something)?
+    H2OP_HEADER *header = (H2OP_HEADER*) buf;
+    header->magic = H2OP_MAGIC;
+    header->version = H2OP_VERSION;
+    header->len = H2OP_HEADER_LENGTH+len;
+    header->type = type;
+    header->node = source;
+    header->crc = 0;
+    memcpy(buf+H2OP_HEADER_LENGTH, data, len);
+    crc16_ccitt_calc(buf, H2OP_HEADER_LENGTH+len);
+
+    h2op_header_hton(header);
+    rv = udp_send(&recipient_ip, H2OP_PORT, buf, buflen);
+    free(buf);
+    return rv;
+}
+
 void h2op_debug_receive_handler ( char *buf, uint16_t packetlen ) {
+    /* print contents of h2op package to stdout */
     if ( packetlen < H2OP_HEADER_LENGTH ) {
         error(0,0, "invalid packet received: length < %u", H2OP_HEADER_LENGTH);
         return;
@@ -78,11 +170,11 @@ void h2op_debug_receive_handler ( char *buf, uint16_t packetlen ) {
     H2OP_HEADER *header = (H2OP_HEADER*) buf;
     h2op_header_ntoh(header);
 
-    if ( header->magic != 0xac ) {
+    if ( header->magic != H2OP_MAGIC ) {
         error(0,0, "invalid magic number (got 0x%02X, want 0xAC)", header->magic);
         return;
     }
-    if ( header->version != 0x01) {
+    if ( header->version != H2OP_VERSION ) {
         error(0,0, "invalid version (got 0x%02X, want 0x01)", header->version);
         return;
     }
@@ -110,6 +202,39 @@ int h2o_dump_server ( int argc, char *argv[]) {
     puts("printf '\\xac\\x01\\x0c\\x00\\x12\\x34\\x00\\x00DATA' "
          "| nc -6u ff02::1%tapbr0 44555");
 
-    udp_server(H2OP_SERVER_PORT, &h2op_debug_receive_handler);
+    udp_server(H2OP_PORT, &h2op_debug_receive_handler);
     return 0;
+}
+
+int h2o_send_data_shell ( int argc, char *argv[]) {
+    if ( argc != 5 ) {
+        printf("Usage: %s from(nodeid) to(nodeid) "
+             "[temperature|humidity] value(0..255)\n", argv[0]);
+        return 1;
+    }
+    nodeid_t from = strtoul(argv[1], NULL, 16);
+    nodeid_t to = strtoul(argv[2], NULL, 16);
+    int16_t value = strtol(argv[4], NULL, 10);
+
+    H2OP_MSGTYPE type;
+    if ( argv[3][0] == 't' ) {
+        type = H2OP_DATA_TEMPERATURE;
+    } else if ( argv[3][0] == 'h' ) {
+        type = H2OP_DATA_HUMIDITY;
+    } else {
+        fprintf(stderr, "Invalid argument: %s (must be one of temperature, "
+                "humidity)\n", argv[3]);
+    }
+
+    //XXX: why is there no network_int16_t in RIOT?
+    int16_t netval = htons(value);
+
+    rv = h2op_send(to, type, (char*) &netval, sizeof(value), from);
+    if ( rv <= 0 ) {
+        error(0,-rv, "could not send data");
+        return 1;
+    } else {
+        puts("Data sent.");
+        return 0;
+    }
 }

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@ static const shell_command_t shell_commands[] = {
     { "light", "read light data", read_light },
     { "humidity", "read humidity data", read_humidity },
     { "h2o_dumpd", "start debug h2o server that just prints data it receives", h2o_dump_server },
+    { "h2o_send_data", "send data using the h2o protocol", h2o_send_data_shell },
     { NULL, NULL, NULL },
 };
 


### PR DESCRIPTION
you can now send and receive on the shell (`h2o_data_send`, `h2o_dumpd`). (To try, run `make term` with `PORT=tap0` and a second time with `tap1`).