### PR TITLE
calibrate sensors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "RIOT"]
 	path = RIOT
-	url = https://github.com/RIOT-OS/RIOT.git
+	url = https://github.com/fu-ilab-swp18/RIOT_pflanzen1.git


### PR DESCRIPTION
Calibrate the sensors by:
* setting a internal reference voltage of 2V for the ADC
* calibrate offset & gain in software in the samr21-xpro implementation of sensor.c

To get the modified samr21 defines that give 2V ref voltage, do:
* `git submodule update --init`
* `cd RIOT`
* `git checkout master`